### PR TITLE
Fix for literal tests

### DIFF
--- a/test/UtteranceTest.ts
+++ b/test/UtteranceTest.ts
@@ -80,7 +80,7 @@ const intentSchema: IIntentSchema = {
 const sampleUtterancesValues = {
     CustomSlot: ["{country}"],
     Hello: ["hi", "hello", "hi there", "good morning"],
-    LiteralInput: ["{first literal input | literal}", "{second literal input | literal}"],
+    LiteralInput: ["literally {first literal input | literal}", "literally {second literal input | literal}"],
     MultipleSlots: ["multiple {SlotA} and {SlotB}", "reversed {SlotB} then {SlotA}", "{SlotA}"],
     NumberSlot: ["{number}", "{number} test"],
     Play: ["play", "play next", "play now"],
@@ -221,7 +221,9 @@ describe("UtteranceTest", function() {
         });
 
         it("Matches a literal slot", () => {
-            const utterance = new Utterance(model, "second literal input");
+            // Ensures that slots with utterances in the form of { sample | slotName } are parsed correctly
+            // This is the standard syntax for AMAZON.LITERAL slots
+            const utterance = new Utterance(model, "literally second literal input");
             assert.isTrue(utterance.matched());
             assert.equal(utterance.intent(), "LiteralInput");
             assert.equal(utterance.matchedSample.slotName(0), "literal");


### PR DESCRIPTION
This is a slight change to the PR that you created.

The reason for this is that the tests will arbitrarily pick a winner when two intents with "naked" literal slots are offered. A naked literal intent is one with an utterance like this: "{LiteralSlot}".

There is a second literal slot {SlotA}. Though not actually specified as a literal, we treat it in the same way, since it does not have a type. This is a common thing for skills that use the old-style intent schema definition.

The fix is simply to ensure the intent schema does not have two "naked" literal intents.